### PR TITLE
Agrega un spinner al botón de envío del formulario de suscripción de …

### DIFF
--- a/src/newsletter/components/SubscribeForm.astro
+++ b/src/newsletter/components/SubscribeForm.astro
@@ -2,6 +2,21 @@
 import { actions } from "astro:actions"
 ---
 
+<style>
+  @keyframes spin {
+    from {
+      transform: rotate(0deg);
+    }
+    to {
+      transform: rotate(360deg);
+    }
+  }
+  
+  .spinner {
+    animation: spin 1s linear infinite;
+  }
+</style>
+
 <section class="w-full max-w-xl mx-auto">
   <form
     method="POST"
@@ -19,8 +34,16 @@ import { actions } from "astro:actions"
       />
       <button
         type="submit"
-        class="px-6 py-3 bg-brand hover:bg-yellow-400 text-black font-bold rounded-lg transition-all hover:scale-105 active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:scale-100"
-        >¡Avísame!
+        id="submit-button"
+        class="px-6 py-3 bg-brand hover:bg-yellow-400 text-black font-bold rounded-lg transition-all hover:scale-105 active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:scale-100 relative"
+      >
+        <span id="button-text">¡Avísame!</span>
+        <span id="button-loader" class="hidden absolute inset-0 flex items-center justify-center">
+          <svg class="spinner h-5 w-5 text-black" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+            <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+            <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+          </svg>
+        </span>
       </button>
     </div>
 
@@ -38,6 +61,9 @@ import { actions } from "astro:actions"
   const message = document.getElementById(
     "newsletter-message"
   ) as HTMLDivElement
+  const submitButton = document.getElementById("submit-button") as HTMLButtonElement
+  const buttonText = document.getElementById("button-text") as HTMLSpanElement
+  const buttonLoader = document.getElementById("button-loader") as HTMLSpanElement
 
   message.classList.add("hidden")
   message.classList.remove("text-red-500", "text-green-500")
@@ -47,10 +73,20 @@ import { actions } from "astro:actions"
 
     event.preventDefault()
 
+    // Activar estado de carga
+    submitButton.disabled = true
+    buttonText.classList.add("invisible")
+    buttonLoader.classList.remove("hidden")
+
     const formData = new FormData(form)
     const email = formData.get("email") as string
 
     const { data, error } = await actions.newsletter({ email })
+
+    // Desactivar estado de carga
+    submitButton.disabled = false
+    buttonText.classList.remove("invisible")
+    buttonLoader.classList.add("hidden")
 
     if (error) {
       const messageText = isInputError(error)


### PR DESCRIPTION
Describe your changes
---
Agrega un spinner al botón de envío del formulario de suscripción de emails y gestiona el estado de carga durante el envío.

Básicamente, en caso de que el usuario tarde en poder hacer la petición (ej. móvil con baja cobertura de internet) que salga una animación de que se está procesando la información y no se piense que no va el botón.

Include a screenshot/video where applicable
---
He añadido en el video de demostración un delay simulado (no está hecho en el commit) para poder ver la animación correctamente.

https://github.com/user-attachments/assets/17d391e0-151d-4283-873d-52b0c2e43dd3

