### PR TITLE
fix: Fixes mobile layout for header and footer sections

### DIFF
--- a/src/sections/Footer.astro
+++ b/src/sections/Footer.astro
@@ -1,5 +1,6 @@
 <footer class="pt-10 text-white pb-4">
-  <div class="w-full max-w-xl mx-auto p-4 flex justify-between items-center">
+  <div class="w-full max-w-xl mx-auto p-4 flex flex-col gap-4 md:gap-0 md:flex-row justify-between items-center"
+  >
     <a href="/">
       <img
         class="w-24 drop-shadow drop-shadow-black/30"
@@ -9,22 +10,22 @@
     </a>
 
     <nav>
-      <ul class="flex justify-center items-center">
+      <ul class="flex flex-wrap gap-4 md:gap-6 justify-center items-center">
         <li>
           <a
-            class="hover:underline hover:text-yellow-300 transition me-4 md:me-6"
+            class="hover:underline hover:text-yellow-300 transition"
             href="/privacidad">Privacidad</a
           >
         </li>
         <li>
           <a
-            class="hover:underline hover:text-yellow-300 transition me-4 md:me-6"
+            class="hover:underline hover:text-yellow-300 transition"
             href="/aviso-legal">Aviso Legal</a
           >
         </li>
         <li>
           <a
-            class="hover:underline hover:text-yellow-300 transition me-4 md:me-6"
+            class="hover:underline hover:text-yellow-300 transition"
             href="/politica-de-cookies">Política de Cookies</a
           >
         </li>

--- a/src/sections/Header.astro
+++ b/src/sections/Header.astro
@@ -1,6 +1,6 @@
 <header class="pt-24">
   <div class="relative">
-    <img class="max-w-xl mx-auto" src="/logo-a.svg" alt="bigibai logo" />
+    <img class="max-w-xl mx-auto px-4 md:px-0" src="/logo-a.svg" alt="bigibai logo" />
     <img
       class="inline-block absolute top-0 left-0 blur-sm w-full h-full opacity-50 -z-10 pulse"
       src="/logo-a.svg"


### PR DESCRIPTION
320px width

AFTER
<img width="640" height="1844" alt="localhost_4321_(iPhone 5_SE) (1)" src="https://github.com/user-attachments/assets/cdb8b8cf-b2c4-49a7-a47b-148b57d43507" />

BEFORE
<img width="640" height="1944" alt="localhost_4321_(iPhone 5_SE)" src="https://github.com/user-attachments/assets/cff8c87e-1439-44ec-912e-36170f0b5fc9" />
