### PR TITLE
Agregando no-select classes a imagenes

### DIFF
--- a/src/sections/Footer.astro
+++ b/src/sections/Footer.astro
@@ -2,7 +2,7 @@
   <div class="w-full max-w-xl mx-auto p-4 flex justify-between items-center">
     <a href="/">
       <img
-        class="w-24 drop-shadow drop-shadow-black/30"
+        class="w-24 drop-shadow drop-shadow-black/30 select-none"
         src="/logo-a.svg"
         alt="bigibai logo"
       />

--- a/src/sections/Header.astro
+++ b/src/sections/Header.astro
@@ -1,8 +1,8 @@
 <header class="pt-24">
   <div class="relative">
-    <img class="max-w-xl mx-auto" src="/logo-a.svg" alt="bigibai logo" />
+    <img class="max-w-xl mx-auto select-none" src="/logo-a.svg" alt="bigibai logo" />
     <img
-      class="inline-block absolute top-0 left-0 blur-sm w-full h-full opacity-50 -z-10 pulse"
+      class="inline-block absolute top-0 left-0 blur-sm w-full h-full opacity-50 -z-10 pulse select-none"
       src="/logo-a.svg"
       alt="bigibai logo"
     />


### PR DESCRIPTION
Al seleccionar el contenido de la pagina se pueden seleccionar las imagenes, incluso se ve como la imagen en blur pierde la opacidad

Antes
<img width="1869" height="947" alt="Screenshot 2025-10-07 at 20-03-00 bigibai - ¡Algo grande se acerca!" src="https://github.com/user-attachments/assets/77256b5a-d68a-4f21-8aa1-1f32ec512baf" />

Despues 
<img width="1869" height="947" alt="Screenshot 2025-10-07 at 20-05-10 bigibai - ¡Algo grande se acerca!" src="https://github.com/user-attachments/assets/b45fea0b-7b04-4b6f-8527-6dbbe909ce20" />

