### PR TITLE
fix: reset del newsletter input en envío exitoso y ocultar alerta al enfocar

### DIFF
--- a/src/newsletter/components/SubscribeForm.astro
+++ b/src/newsletter/components/SubscribeForm.astro
@@ -24,7 +24,7 @@ import { actions } from "astro:actions"
       </button>
     </div>
 
-    <div id="newsletter-message" class="hidden text-sm text-center text-brand">
+    <div id="newsletter-message" class="invisible block h-6 leading-6 text-sm text-center text-brand">
       ¡Ya eres parte de la newsletter!
     </div>
   </form>
@@ -39,8 +39,16 @@ import { actions } from "astro:actions"
     "newsletter-message"
   ) as HTMLDivElement
 
-  message.classList.add("hidden")
+  message.classList.add("invisible")
   message.classList.remove("text-red-500", "text-green-500")
+
+  const input = form.querySelector("input[name='email']") as HTMLInputElement
+
+  input.addEventListener("focus", () => {
+    message.classList.add("invisible")
+    message.classList.remove("text-red-500", "text-green-500")
+    message.textContent = ""
+  })
 
   form.addEventListener("submit", async (event) => {
     console.log("submit")
@@ -59,15 +67,16 @@ import { actions } from "astro:actions"
 
       message.textContent =
         messageText ?? "Error al guardar el email en la newsletter"
-      message.classList.remove("hidden")
+      message.classList.remove("invisible")
       message.classList.add("text-red-500")
     }
 
     if (data) {
       throwConfetti()
       message.textContent = data.message
-      message.classList.remove("hidden")
+      message.classList.remove("invisible")
       message.classList.add("text-green-500")
+      form.reset()
     }
   })
 </script>


### PR DESCRIPTION
## Descripción  
Este PR mejora la UX del formulario de suscripción a la newsletter:  
- Se **resetea** el campo de email tras un envío **exitoso**.  
- Se **oculta** el mensaje de alerta al volver a **enfocar** el campo.  
- Se fija la altura del contenedor del mensaje para **evitar saltos en el layout**.  

## Tipo de cambio  
- [x] 🐛 Corrección de bug  
- [x] 🎨 Mejora de UI/UX  

## Checklist  
- [x] He probado los cambios localmente y funcionan como se espera.  
- [x] Mis cambios no generan nuevas advertencias o errores.  

## Capturas  

https://github.com/user-attachments/assets/32c909fb-72a2-443d-b60d-714c59f771a4

