### PR TITLE
fix: corregir enlace de issues en README que apuntaba a la-velada-web…

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,6 @@ El proyecto se construye en stream a traves de Twitch y Youtube, de forma colabo
 [stars-shield]: https://img.shields.io/github/stars/midudev/bigibai-2025.svg?style=for-the-badge
 [stars-url]: https://github.com/midudev/bigibai-2025/stargazers
 [issues-shield]: https://img.shields.io/github/issues/midudev/bigibai-2025.svg?style=for-the-badge
-[issues-url]: https://github.com/midudev/la-velada-web-oficial/issues
+[issues-url]: https://github.com/midudev/bigibai-2025/issues
 [supabase-url]: https://supabase.com/
 [supabase-badge]: https://img.shields.io/badge/Supabase-3ECF8E?style=for-the-badge&logo=supabase&logoColor=white


### PR DESCRIPTION
## Description
Corrige el enlace del badge de Issues en el README que apuntaba incorrectamente al repositorio `la-velada-web-oficial` en lugar de `bigibai-2025`.

## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Code refactor
- [ ] 📚 Documentation update
- [ ] ⚡ Performance improvement
- [ ] 🎨 UI/UX improvement
- [ ] 🚀 Other (please describe):

## CheckList
- [x] I have tested my changes locally and they work as intended.
- [x] My changes generate no new warnings or errors.

## Include screenshots or a video (if applicable)
No aplica para este cambio de documentación.

## Additional Notes
El enlace estaba apuntando al proyecto anterior "La Velada" en lugar del proyecto actual "BigIbai 2025". Esto causaba que el badge de Issues llevara a los usuarios al repositorio equivocado.