### PR TITLE
Fix(SubscribeForm): feedback color for newsletter submission flow

### DIFF
--- a/src/newsletter/components/SubscribeForm.astro
+++ b/src/newsletter/components/SubscribeForm.astro
@@ -104,6 +104,7 @@ import { actions } from "astro:actions"
       message.textContent =
         messageText ?? "Error al guardar el email en la newsletter"
       message.classList.remove("invisible")
+      message.classList.remove("text-red-500")
       message.classList.add("text-red-500")
     }
 
@@ -111,6 +112,7 @@ import { actions } from "astro:actions"
       throwConfetti()
       message.textContent = data.message
       message.classList.remove("invisible")
+      message.classList.remove("text-red-500")
       message.classList.add("text-green-500")
       form.reset()
     }


### PR DESCRIPTION
## Description
<!-- Please provide a clear and concise description of what this pull request does. -->
Cuando se hace un submit con el enter y no con el boton "Avísame", no se elimina el color anterior del texto y entonces se mantiene rojo al segundo intento.

## Type of Change
<!-- Please mark the relevant option with an "x". -->

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Code refactor
- [ ] 📚 Documentation update
- [ ] ⚡ Performance improvement
- [x] 🎨 UI/UX improvement
- [ ] 🚀 Other (please describe):

## CheckList
<!-- Please ensure you have completed these steps before requesting a review. -->

- [x] I have tested my changes locally and they work as intended.
- [x] My changes generate no new warnings or errors.

## Include screenshots or a video (if applicable)
<!-- For UI changes, it's highly recomended to include before/after screenshots. -->

Antes:

https://github.com/user-attachments/assets/b8a23147-ba3c-4e35-888e-7cd6af36f07c


Despues:

https://github.com/user-attachments/assets/b39d1d4b-08bf-4585-b707-bac112a4ff38


## Additional Notes
<!-- Add any other context, questions, or notes for the reviewers here. -->