### PR TITLE
refactor: remove header from 404 page

### DIFF
--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,12 +1,10 @@
 ---
 import Layout from "@/layouts/Layout.astro";
 import Footer from "@/sections/Footer.astro";
-import Header from "@/sections/Header.astro";
 ---
 
 <Layout>
   <div class="flex min-h-screen flex-col">
-    <Header />
     <div class="flex flex-1">
       <section
         class="max-w-4xl mx-auto px-4 py-20 flex justify-center items-center flex-col gap-8"


### PR DESCRIPTION
Considero que en la página 404 es mejor quitar el header:

<img width="1918" height="935" alt="bigibai404-before" src="https://github.com/user-attachments/assets/70801c5a-e2a6-48f2-b597-73a736516334" />

<img width="1918" height="936" alt="bigibai404-after" src="https://github.com/user-attachments/assets/23da7ea1-05ef-43f5-beee-57bab644286d" />
