### PR TITLE
Corregir meta tags de Open Graph usando property en lugar de name

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -42,9 +42,9 @@ const description =
     <meta name="keywords" content="bigibai" />
     <meta name="author" content="Ibai Llanos" />
 
-    <meta name="og:title" content={title} />
-    <meta name="og:description" content={description} />
-    <meta name="og:image" content="https://www.bigibai.com/og.jpg" />
+    <meta property="og:title" content={title} />
+    <meta property="og:description" content={description} />
+    <meta property="og:image" content="https://www.bigibai.com/og.jpg" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:creator" content="@IbaiLlanos" />
     <meta name="twitter:title" content={title} />


### PR DESCRIPTION
## Description

Corregí un bug en las meta tags de Open Graph en el componente [Layout.astro](). Las tags estaban usando el atributo `name` cuando deberían usar `property`, lo que impedía que las redes sociales pudieran leer correctamente la información del sitio al compartir URLs.

**¿Qué cambió?**
- `<meta name="og:title"` → `<meta property="og:title"`
- `<meta name="og:description"` → `<meta property="og:description"`  
- `<meta name="og:image"` → `<meta property="og:image"`

**¿Por qué es importante?**
El protocolo Open Graph requiere que estas meta tags usen `property`, no `name`. Con este cambio, cuando alguien comparta la web en Facebook, WhatsApp, LinkedIn, Discord, etc., se mostrará correctamente el título, descripción e imagen.

Las meta tags de Twitter (`twitter:card`, etc.) siguen usando `name` correctamente, que es como debe ser.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Code refactor
- [ ] 📚 Documentation update
- [ ] ⚡ Performance improvement
- [ ] 🎨 UI/UX improvement
- [ ] 🚀 Other (please describe):

## CheckList

- [x] I have tested my changes locally and they work as intended.
- [x] My changes generate no new warnings or errors.

## Include screenshots or a video (if applicable)

No aplica para este cambio ya que las meta tags no son visibles en la UI. Para verificar que funciona correctamente, se puede usar el [Facebook Sharing Debugger](https://developers.facebook.com/tools/debug/) después del deploy.

**Referencia del protocolo:** https://ogp.me/

## Additional Notes

Es un cambio pequeño pero importante para el SEO y la visibilidad en redes sociales. Afecta cómo se ve el sitio cuando se comparte en cualquier plataforma que use Open Graph (prácticamente todas).