### PR TITLE
feat(newsletter): auto-hide success/error messages after 10s

### DIFF
--- a/src/newsletter/components/SubscribeForm.astro
+++ b/src/newsletter/components/SubscribeForm.astro
@@ -208,6 +208,7 @@ import Button from "@/components/Button.astro"
   const buttonLoader = document.getElementById(
     "button-loader"
   ) as HTMLSpanElement
+  let hideTimer: number | null = null
 
   message.classList.add("invisible")
   message.classList.remove("text-white", "text-black")
@@ -240,6 +241,83 @@ import Button from "@/components/Button.astro"
     message.setAttribute("aria-live", "polite")
   })
 
+  const clearHideTimer = () => {
+    if (hideTimer !== null) {
+      clearTimeout(hideTimer)
+      hideTimer = null
+    }
+  }
+
+  const hideMessage = () => {
+    clearHideTimer()
+    message.textContent = ""
+    message.classList.add("invisible")
+    newsletterToastIcon.classList.add("invisible")
+    message.classList.remove("text-red-500", "text-green-500", "error-shake", "success-bounce")
+    message.removeAttribute("role")
+    message.setAttribute("aria-live", "polite")
+    input.removeAttribute("aria-invalid")
+    try { message.removeAttribute("tabindex") } catch {}
+  }
+
+  const showMessage = (type: "error" | "success", text: string) => {
+    clearHideTimer()
+
+    message.textContent = text
+
+    if (type === "error") {
+      message.classList.remove("invisible")
+      message.classList.remove(
+        "from-yellow-400",
+        "to-orange-300",
+        "shadow",
+        "shadow-amber-200"
+      )
+      newsletterToastIcon.src =
+        "https://png.pngtree.com/png-clipart/20250421/original/pngtree-cross-icon-wrong-sign-vector-with-transparent-background-png-image_20826131.png"
+      newsletterToastIcon.classList.remove("invisible")
+      newsletterToastIcon.classList.add("animate-shake")
+      newsletterToastIcon.addEventListener("animationend", () => {
+        newsletterToastIcon.classList.remove("animate-shake")
+      })
+      newsletterToastIcon.classList.remove("-rotate-45")
+      newsletterToastIcon.classList.remove("hover:-rotate-[40deg]")
+      newsletterToastIcon.classList.add("hover:-rotate-12")
+
+      message.classList.add("opacity-100")
+      message.classList.add("translate-y-0")
+      message.classList.add("scale-100")
+      message.classList.add(
+        "from-red-400",
+        "to-pink-600",
+        "shadow",
+        "shadow-pink-400",
+        "text-white"
+      )
+    } else {
+      message.classList.remove("invisible")
+      message.classList.add("opacity-100")
+      message.classList.add("translate-y-0")
+      message.classList.add("scale-100")
+      message.classList.add("text-black")
+
+      message.classList.add(
+        "from-yellow-400",
+        "to-orange-300",
+        "shadow",
+        "shadow-amber-200"
+      )
+      newsletterToastIcon.classList.remove("invisible")
+      message.setAttribute("tabindex", "-1")
+      ;(message as HTMLDivElement).focus()
+    }
+
+    // Hide message after 10 seconds
+    hideTimer = window.setTimeout(() => {
+      hideMessage()
+    }, 10 * 1000)
+  }
+
   form.addEventListener("submit", async (event) => {
     console.log("submit")
 
@@ -270,58 +348,15 @@ import Button from "@/components/Button.astro"
       const messageText = isInputError(error)
         ? error?.fields?.email?.join(", ")
         : error.message
-
-      message.textContent =
-        messageText ?? "Error al guardar el email en la newsletter"
-      message.classList.remove("invisible")
-      message.classList.remove(
-        "from-yellow-400",
-        "to-orange-300",
-        "shadow",
-        "shadow-amber-200"
-      )
-      newsletterToastIcon.src =
-        "https://png.pngtree.com/png-clipart/20250421/original/pngtree-cross-icon-wrong-sign-vector-with-transparent-background-png-image_20826131.png"
-      newsletterToastIcon.classList.remove("invisible")
-      newsletterToastIcon.classList.add("animate-shake")
-      newsletterToastIcon.addEventListener("animationend", () => {
-        newsletterToastIcon.classList.remove("animate-shake")
-      })
-      newsletterToastIcon.classList.remove("-rotate-45")
-      newsletterToastIcon.classList.remove("hover:-rotate-[40deg]")
-      newsletterToastIcon.classList.add("hover:-rotate-12")
-
-      message.classList.add("opacity-100")
-      message.classList.add("translate-y-0")
-      message.classList.add("scale-100")
-      message.classList.add(
-        "from-red-400",
-        "to-pink-600",
-        "shadow",
-        "shadow-pink-400",
-        "text-white"
-      )
+      showMessage("error", messageText ?? "Error al guardar el email en la newsletter")
+      return
     }
 
     if (data) {
       throwConfetti()
-      message.textContent = data.message
-      message.classList.remove("invisible")
-      message.classList.add("opacity-100")
-      message.classList.add("translate-y-0")
-      message.classList.add("scale-100")
-      message.classList.add("text-black")
-
-      message.classList.add(
-        "from-yellow-400",
-        "to-orange-300",
-        "shadow",
-        "shadow-amber-200"
-      )
-      newsletterToastIcon.classList.remove("invisible")
+      showMessage("success", data.message)
       form.reset()
-      message.setAttribute("tabindex", "-1")
-      ;(message as HTMLDivElement).focus()
+      return
     }
   })
 </script>


### PR DESCRIPTION
## Description

Hace que los mensajes de la suscripción (tanto de éxito como de error) se oculten automáticamente después de 10 segundos. Para ello se centraliza la lógica de notificación dentro de `SubscribeForm.astro` usando:

- una variable `hideTimer` para controlar el timeout,
- `showMessage(type, text)` para mostrar mensajes (gestiona roles ARIA, focus y animaciones),
- `hideMessage()` y `clearHideTimer()` para ocultar mensajes y cancelar timers previos.

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] ♻️ Code refactor
- [ ] 📚 Documentation update
- [ ] ⚡ Performance improvement
- [x] 🎨 UI/UX improvement
- [ ] 🚀 Other (please describe):

## CheckList

- [x] I have tested my changes locally and they work as intended.
- [x] My changes generate no new warnings or errors.

## Include screenshots or a video (if applicable)
Ejemplo con un registro exitoso (mensaje desaparece luego de 10 segundos): 

https://github.com/user-attachments/assets/45851df3-8edd-4b1b-9ef2-5c521ed28c43

Ejemplo con un registro fallido (mensaje desaparece luego de 10 segundos): 

https://github.com/user-attachments/assets/c6830224-1833-4166-8c2f-d9c39612fe21

