### PR TITLE
fix: fix logo jump caused by mixed animations

### DIFF
--- a/src/sections/Header.astro
+++ b/src/sections/Header.astro
@@ -67,9 +67,7 @@
   }
 
   .logo-main {
-    animation:
-      float 4s ease-in-out infinite,
-      fadeInScale 0.8s ease-out;
+    animation: float 4s ease-in-out infinite;
     filter: drop-shadow(0 0 20px rgba(248, 177, 52, 0.4));
   }
 


### PR DESCRIPTION
## Description
Fixed main logo jump caused by mixed animations

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Code refactor
- [ ] 📚 Documentation update
- [ ] ⚡ Performance improvement
- [x] 🎨 UI/UX improvement
- [ ] 🚀 Other (please describe):

## CheckList

- [x] I have tested my changes locally and they work as intended.

## Include screenshots or a video (if applicable)
- Before:
[without-fix-logo.webm](https://github.com/user-attachments/assets/290cab3a-7978-4141-964f-109faa07895f)

- After:
[fixed-logo.webm](https://github.com/user-attachments/assets/acef0793-9d5c-4382-8e5a-95ad67130993)


## Additional Notes

- This is a purely visual change to improve the logo animation on load.