### PR TITLE
fix: remove-initial-loading-animation-tick

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -89,11 +89,13 @@ description ??= defaultDescription;
     />
   </head>
   <body>
-    <div id="background-mask" class="min-h-screen w-full">
-      <GradientOverlay />
-      <Snowballs />
-      <div class="relative z-2">
-        <slot />
+    <div class="overflow-hidden">
+      <div id="background-mask" class="min-h-screen w-full">
+        <GradientOverlay />
+        <Snowballs />
+        <div class="relative z-2">
+          <slot />
+        </div>
       </div>
     </div>
   </body>


### PR DESCRIPTION
Al cargar la página se notaba un pequeño salto visual, sobre todo en pantallas de escritorio (1080p en adelante). No era nada grave, pero se veía un parpadeo rápido ya que se generaba una barra de scroll "falsa" que aparecía y desaparecía justo antes de que la página terminara de renderizar debido a la animación.

Esto pasaba porque el contenido del se desbordaba un instante mientras se montaban los componentes del fondo (GradientOverlay, Snowballs, etc.).