### PR TITLE
style(header): arreglar corte del blur en el logo

### DIFF
--- a/src/sections/Header.astro
+++ b/src/sections/Header.astro
@@ -1,4 +1,4 @@
-<header class="pt-24 overflow-hidden pb-5" aria-label="Big Ibai">
+<header class="pt-24 overflow-x-clip pb-5" aria-label="Big Ibai">
   <div class="relative logo-container">
     <img
       class="max-w-xl mx-auto px-4 md:px-0 relative z-10 logo-main"


### PR DESCRIPTION
## Description

Se cambió `overflow-hidden` por `overflow-x-clip` en src/sections/Header.astro.
para evitar el corte en el desenfoque de la imagen de fondo

```diff 
- <header class="pt-24 overflow-hidden pb-5" aria-label="Big Ibai">
+ <header class="pt-24 overflow-x-clip pb-5" aria-label="Big Ibai">
  <div class="relative logo-container">
    <img
      class="max-w-xl mx-auto px-4 md:px-0 relative z-10 logo-main"
```

_Capaz cambio muy menor pero queria probar hacer una pr :D_

## Type of Change
<!-- Please mark the relevant option with an "x". -->

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Code refactor
- [ ] 📚 Documentation update
- [ ] ⚡ Performance improvement
- [x] 🎨 UI/UX improvement
- [ ] 🚀 Other (please describe):

## Include screenshots or a video (if applicable)
<!-- For UI changes, it's highly recomended to include before/after screenshots. -->

### Antes
<img width="967" height="356" alt="image" src="https://github.com/user-attachments/assets/a6a276f6-7504-469a-a5e2-dc18191c24c5" />

### Ahora
<img width="967" height="356" alt="image" src="https://github.com/user-attachments/assets/5606cdd0-d2c8-43b6-925b-2e649edaaeb4" />
